### PR TITLE
Fix build with GCC 10

### DIFF
--- a/main.c
+++ b/main.c
@@ -10,6 +10,8 @@
 
 #include "sweep.h"
 
+DrawChars CharSet;
+
 int main(int argc, char** argv)
 {
 	GameStats* Game;

--- a/sweep.h.in
+++ b/sweep.h.in
@@ -246,7 +246,7 @@ struct FileBuf
 FILE* DebugLog;
 #endif /* DEBUG_LOG */
 
-DrawChars CharSet;
+extern DrawChars CharSet;
 
 /* These are the functions defined in files.c */
 int SourceHomeFile(GameStats* Game);


### PR DESCRIPTION
mark variable declaration in sweep.h as extern, as otherwise
linker would complain about multiple definitions.
keep actual declaration in a C file.

See also: https://gcc.gnu.org/gcc-10/porting_to.html