### PR TITLE
freesweep: always use "%s"-style format for printf()-style functions

### DIFF
--- a/drawing.c
+++ b/drawing.c
@@ -593,7 +593,7 @@ void Help()
 		CurrentY=4;
 		while (CurrentY< (LINES -2 ))
 		{
-			mvwprintw(HelpWin,CurrentY++,8,Messages[CurrentLine++]);
+			mvwprintw(HelpWin,CurrentY++,8,"%s",Messages[CurrentLine++]);
 			LinesLeft--;
 		}
 		/* Now get a keystroke to continue. */
@@ -633,7 +633,7 @@ void Help()
 	CurrentY=4;
 	while (LinesLeft > 0)
 	{
-			mvwprintw(HelpWin,CurrentY++,8,Messages[CurrentLine++]);
+			mvwprintw(HelpWin,CurrentY++,8,"%s",Messages[CurrentLine++]);
 			LinesLeft--;
 	}
 	wmove(HelpWin,0,0);

--- a/error.c
+++ b/error.c
@@ -43,7 +43,7 @@ void SweepError(char* format, ...)
 #endif
 		va_end(args);
 
-		mvwprintw(ErrWin,0,0,NewErrMsg);
+		mvwprintw(ErrWin,0,0,"%s",NewErrMsg);
 
 		SweepAlert();
 	}
@@ -126,7 +126,7 @@ void SweepMessage(char* format, ...)
 #error "Need either vsnprintf() (preferred) or vsprintf()"
 #endif
 	va_end(args);
-	mvwprintw(ErrWin,0,0,NewErrMsg);
+	mvwprintw(ErrWin,0,0,"%s",NewErrMsg);
 	wnoutrefresh(ErrWin);
 	move(0,0);
 	noutrefresh();

--- a/fgui.c
+++ b/fgui.c
@@ -305,13 +305,13 @@ void Display(WINDOW *fgui, struct FileBuf *fb, int find,
 
 	/* display the path, on the first line */
 	mvwprintw(fgui, 0, 0, "-->");
-	mvwprintw(fgui, 0, 3, fb[0].path);
+	mvwprintw(fgui, 0, 3, "%s", fb[0].path);
 
 	for (i = 0; i < amount && i+find < fb[0].numents; i++)
 	{
 		p = fb[find+i].fpath + strlen(fb[find+i].fpath) - 1;
 		while(*p != '/') p--; p++; /* there will always be a / in it */
-		mvwprintw(fgui, i+1, 1, p);
+		mvwprintw(fgui, i+1, 1, "%s", p);
 	}
 
 	/* highlight the cursor line */

--- a/gpl.c
+++ b/gpl.c
@@ -381,7 +381,7 @@ void PrintGPL()
 		CurrentY=4;
 		while (CurrentY< (LINES -2 ))
 		{
-			mvwprintw(GPLWin,CurrentY++,2,Messages[CurrentLine++]);
+			mvwprintw(GPLWin,CurrentY++,2,"%s",Messages[CurrentLine++]);
 			LinesLeft--;
 		}
 		/* Now get a keystroke to continue. */
@@ -413,7 +413,7 @@ void PrintGPL()
 	CurrentY=4;
 	while (LinesLeft > 0)
 	{
-			mvwprintw(GPLWin,CurrentY++,2,Messages[CurrentLine++]);
+			mvwprintw(GPLWin,CurrentY++,2,"%s",Messages[CurrentLine++]);
 			LinesLeft--;
 		
 	}


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    gpl.c:416:25: error: format not a string literal and no format arguments [-Werror=format-security]
      416 |                         mvwprintw(GPLWin,CurrentY++,2,Messages[CurrentLine++]);
          |                         ^~~~~~~~~

Let's wrap all the missing places with "%s" format.